### PR TITLE
feat: overload mock client response to return strings

### DIFF
--- a/src/KiotaClientMockExtensions.cs
+++ b/src/KiotaClientMockExtensions.cs
@@ -173,4 +173,41 @@ public static class KiotaClientMockExtensions
             )
             .Returns(returnObject);
     }
+
+    /// <summary>
+    /// Mocks a string response for a Kiota client request.
+    /// </summary>
+    /// <typeparam name="T">The type of the Kiota client request builder.</typeparam>
+    /// <param name="mockedClient">The mocked client request builder instance.</param>
+    /// <param name="urlTemplate">The URL template to match the request.</param>
+    /// <param name="returnValue">The string to return as the response.</param>
+    /// <param name="requestInfoPredicate">
+    /// An optional predicate to further filter the request information.
+    /// </param>
+    public static void MockClientResponse<T>(
+        this T mockedClient,
+        string urlTemplate,
+        string? returnValue,
+        Expression<Predicate<RequestInformation>>? requestInfoPredicate = null
+    )
+        where T : BaseRequestBuilder
+    {
+        var requestAdapter = GetRequestAdapter(mockedClient);
+
+        var requestInformationUrlTemplatePredicate = RequestInformationUrlTemplatePredicate(
+            urlTemplate
+        );
+        var requestInformationPredicate =
+            requestInfoPredicate != null
+                ? requestInfoPredicate.And(requestInformationUrlTemplatePredicate)
+                : requestInformationUrlTemplatePredicate;
+
+        requestAdapter
+            ?.SendPrimitiveAsync<string>(
+                Arg.Is(requestInformationPredicate),
+                Arg.Any<Dictionary<string, ParsableFactory<IParsable>>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(returnValue);
+    }
 }


### PR DESCRIPTION
<!-- Update the title following: https://www.notion.so/Pull-request-be8516b1b61a40e5af6f8ae3385487fe?pvs=4 -->

<!-- Add Task ID, i.e. This PR closes GAINS-*** -->
This PR closes GAINS-628

## Description

- feat: overload method `MockClientResponse` to return a string used in Solana api for that returns a public key

<img width="1638" alt="image" src="https://github.com/user-attachments/assets/906e6452-4647-4ba7-9182-5b637774b104" />

<!-- Describe your changes in detail -->

## Checklist:
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] New tests have been added to cover changes.
