### PR TITLE
feat: mock failures

### DIFF
--- a/src/KiotaClientMockExtensions.cs
+++ b/src/KiotaClientMockExtensions.cs
@@ -210,4 +210,158 @@ public static class KiotaClientMockExtensions
             )
             .Returns(returnValue);
     }
+
+    /// <summary>
+    /// Mocks an exception for a Kiota client request that returns a single object.
+    /// </summary>
+    /// <typeparam name="T">The type of the Kiota client request builder.</typeparam>
+    /// <typeparam name="R">The type of the response object.</typeparam>
+    /// <param name="mockedClient">The mocked client request builder instance.</param>
+    /// <param name="urlTemplate">The URL template to match the request.</param>
+    /// <param name="exception">The exception to throw when the request is made.</param>
+    /// <param name="requestInfoPredicate">
+    /// An optional predicate to further filter the request information.
+    /// </param>
+    public static void MockClientResponseException<T, R>(
+        this T mockedClient,
+        string urlTemplate,
+        Exception exception,
+        Expression<Predicate<RequestInformation>>? requestInfoPredicate = null
+    )
+        where T : BaseRequestBuilder
+        where R : IParsable
+    {
+        var requestAdapter = GetRequestAdapter(mockedClient);
+
+        var requestInformationUrlTemplatePredicate = RequestInformationUrlTemplatePredicate(
+            urlTemplate
+        );
+        var requestInformationPredicate =
+            requestInfoPredicate != null
+                ? requestInfoPredicate.And(requestInformationUrlTemplatePredicate)
+                : requestInformationUrlTemplatePredicate;
+
+        requestAdapter
+            ?.SendAsync(
+                Arg.Is(requestInformationPredicate),
+                Arg.Any<ParsableFactory<R>>(),
+                Arg.Any<Dictionary<string, ParsableFactory<IParsable>>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromException<R?>(exception));
+    }
+
+    /// <summary>
+    /// Mocks an exception for a Kiota client request that returns no content.
+    /// </summary>
+    /// <typeparam name="T">The type of the Kiota client request builder.</typeparam>
+    /// <param name="mockedClient">The mocked client request builder instance.</param>
+    /// <param name="urlTemplate">The URL template to match the request.</param>
+    /// <param name="exception">The exception to throw when the request is made.</param>
+    /// <param name="requestInfoPredicate">
+    /// An optional predicate to further filter the request information.
+    /// </param>
+    public static void MockClientNoContentResponseException<T>(
+        this T mockedClient,
+        string urlTemplate,
+        Exception exception,
+        Expression<Predicate<RequestInformation>>? requestInfoPredicate = null
+    )
+        where T : BaseRequestBuilder
+    {
+        var requestAdapter = GetRequestAdapter(mockedClient);
+
+        var requestInformationUrlTemplatePredicate = RequestInformationUrlTemplatePredicate(
+            urlTemplate
+        );
+        var requestInformationPredicate =
+            requestInfoPredicate != null
+                ? requestInfoPredicate.And(requestInformationUrlTemplatePredicate)
+                : requestInformationUrlTemplatePredicate;
+
+        requestAdapter
+            ?.SendNoContentAsync(
+                Arg.Is(requestInformationPredicate),
+                Arg.Any<Dictionary<string, ParsableFactory<IParsable>>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromException(exception));
+    }
+
+    /// <summary>
+    /// Mocks an exception for a Kiota client request that returns a collection.
+    /// </summary>
+    /// <typeparam name="T">The type of the Kiota client request builder.</typeparam>
+    /// <typeparam name="R">The type of the response objects in the collection.</typeparam>
+    /// <param name="mockedClient">The mocked client request builder instance.</param>
+    /// <param name="urlTemplate">The URL template to match the request.</param>
+    /// <param name="exception">The exception to throw when the request is made.</param>
+    /// <param name="requestInfoPredicate">
+    /// An optional predicate to further filter the request information.
+    /// </param>
+    public static void MockClientCollectionResponseException<T, R>(
+        this T mockedClient,
+        string urlTemplate,
+        Exception exception,
+        Expression<Predicate<RequestInformation>>? requestInfoPredicate = null
+    )
+        where T : BaseRequestBuilder
+        where R : IParsable
+    {
+        var requestAdapter = GetRequestAdapter(mockedClient);
+
+        var requestInformationUrlTemplatePredicate = RequestInformationUrlTemplatePredicate(
+            urlTemplate
+        );
+        var requestInformationPredicate =
+            requestInfoPredicate != null
+                ? requestInfoPredicate.And(requestInformationUrlTemplatePredicate)
+                : requestInformationUrlTemplatePredicate;
+
+        requestAdapter
+            ?.SendCollectionAsync(
+                Arg.Is(requestInformationPredicate),
+                Arg.Any<ParsableFactory<R>>(),
+                Arg.Any<Dictionary<string, ParsableFactory<IParsable>>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromException<IEnumerable<R>?>(exception));
+    }
+
+    /// <summary>
+    /// Mocks an exception for a Kiota client request that returns a string.
+    /// </summary>
+    /// <typeparam name="T">The type of the Kiota client request builder.</typeparam>
+    /// <param name="mockedClient">The mocked client request builder instance.</param>
+    /// <param name="urlTemplate">The URL template to match the request.</param>
+    /// <param name="exception">The exception to throw when the request is made.</param>
+    /// <param name="requestInfoPredicate">
+    /// An optional predicate to further filter the request information.
+    /// </param>
+    public static void MockClientResponseException<T>(
+        this T mockedClient,
+        string urlTemplate,
+        Exception exception,
+        Expression<Predicate<RequestInformation>>? requestInfoPredicate = null
+    )
+        where T : BaseRequestBuilder
+    {
+        var requestAdapter = GetRequestAdapter(mockedClient);
+
+        var requestInformationUrlTemplatePredicate = RequestInformationUrlTemplatePredicate(
+            urlTemplate
+        );
+        var requestInformationPredicate =
+            requestInfoPredicate != null
+                ? requestInfoPredicate.And(requestInformationUrlTemplatePredicate)
+                : requestInformationUrlTemplatePredicate;
+
+        requestAdapter
+            ?.SendPrimitiveAsync<string>(
+                Arg.Is(requestInformationPredicate),
+                Arg.Any<Dictionary<string, ParsableFactory<IParsable>>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromException<string?>(exception));
+    }
 }


### PR DESCRIPTION
<!-- Update the title following: https://www.notion.so/Pull-request-be8516b1b61a40e5af6f8ae3385487fe?pvs=4 -->

<!-- Add Task ID, i.e. This PR closes GAINS-*** -->

## Description
This aims to simplify mocking of failing scenarios with Kiota generated clients:

For example this code:

```
var _requestAdapter = Substitute.For<IRequestAdapter>();
_serviceClient = new ServiceClient(_requestAdapter);
_serviceUnderTest = new ServiceUnderTest(
            _serviceDbContext,
            _logger,
            ...
            _serviceClient
            );
            
 _requestAdapter
            .SendCollectionAsync<TModel>(
                Arg.Any<RequestInformation>(),
                Arg.Any<ParsableFactory<TModel>>(),
                Arg.Any<Dictionary<string, ParsableFactory<IParsable>>>(),
                Arg.Any<CancellationToken>()
            )
            .Returns(
                Task.FromException<IEnumerable<TModel>>(
                    new Exception("Unexpected error occurred")
                )
            );            
           
``` 

can be simplified like this:

```
_serviceClient.MockClientCollectionResponseException<
            ServiceClient,
            TModel
        >(
            "/api/path",
            new Exception("Unexpected error occurred"),
            (req) => req.HttpMethod == Method.GET
        );
```

Unfortunately we have to pass both client and model types, as model type cannot be inferred from usage, since we only pass an Exception

## Checklist:
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] New tests have been added to cover changes.
