### PR TITLE
chore(ci): update pr-checker trigger to opened and edited only

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -4,9 +4,6 @@ on:
     types:
       - opened
       - edited
-      - synchronize
-      - labeled
-      - unlabeled
 
 jobs:
   pr-checker:


### PR DESCRIPTION
Updates the pr-checker workflow trigger to only run on pull_request_target types: opened and edited.