### PR TITLE
ci: update permissions on publish as per new template requirements 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,6 @@ jobs:
     with:
       dotnet-version: 10.0.x
     secrets: inherit
+  permissions:
+    contents: read
+    packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
     with:
       dotnet-version: 10.0.x
     secrets: inherit
-  permissions:
-    contents: read
-    packages: write
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -19,9 +19,9 @@ jobs:
     with:
       dotnet-version: 10.0.x
     secrets: inherit
-  permissions:
-    contents: read
-    packages: write
+    permissions:
+      contents: read
+      packages: write
     
   publish-nuget-org:
     name: Publish NuGet.org

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -19,7 +19,10 @@ jobs:
     with:
       dotnet-version: 10.0.x
     secrets: inherit
-
+  permissions:
+    contents: read
+    packages: write
+    
   publish-nuget-org:
     name: Publish NuGet.org
     needs: ci


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow configuration to explicitly set permissions for jobs that interact with packages and repository contents. These changes improve security and ensure the workflows have the correct access for publishing packages.

**Workflow permissions updates:**

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR21-R23): Added `contents: read` and `packages: write` permissions to ensure the CI job can read repository contents and write to GitHub Packages.
* [`.github/workflows/on-tag.yml`](diffhunk://#diff-9adea1c141fb68899b06810643a3824a6f681a51068d1f5fad84a9e404b94f1eR22-R24): Added `contents: read` and `packages: write` permissions to the build job to support package publishing workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation permissions for build and release workflows to support secure package publishing and smoother CI/release runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->