### PR TITLE
ci: use main shared PR checker workflow

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -10,4 +10,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: gainsway/github-workflows/.github/workflows/job.pr-checker.yml@d9014b92c7b874bd23e83be096f96c4582d0958e
+    uses: gainsway/github-workflows/.github/workflows/job.pr-checker.yml@main


### PR DESCRIPTION
Updates the reusable PR checker reference from the pinned commit to `gainsway/github-workflows/.github/workflows/job.pr-checker.yml@main` so GitHub can resolve and run the shared workflow.