### PR TITLE
ci: standardize pr-checker workflow

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,13 +1,17 @@
 name: pr-checker
+
 on:
   pull_request_target:
     types:
       - opened
       - edited
+      - synchronize
+      - labeled
+      - unlabeled
 
 jobs:
   pr-checker:
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     uses: gainsway/github-workflows-public/.github/workflows/job.pr-checker.yml@main


### PR DESCRIPTION
Align `.github/workflows/pr-checker.yml` with the organization-wide canonical wrapper. Public repositories use the public reusable workflow target; all other content is identical.